### PR TITLE
feat: 사용자별 메뉴 내 음식에 대한 최근 점수 조회 기능 추가

### DIFF
--- a/app/crud/foods.py
+++ b/app/crud/foods.py
@@ -1,11 +1,6 @@
-from datetime import datetime
-from typing import List
-
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.models.scores import Score
-from app.schemas.scores import ScoreCreateRequest, ScoreResponse
 from app.models.foods import Food
 from app.schemas.foods import (
     FoodCreateRequest, 
@@ -73,43 +68,3 @@ def update_food(db: Session, food_id: int, new_food: FoodPatchRequest) -> FoodRe
     db.refresh(food)
 
     return FoodResponse.model_validate(food)
-
-
-def score_food(db: Session, user_id: str, score_list: List[ScoreCreateRequest]) -> List[ScoreResponse]:
-    """
-    음식에 대한 평가 점수를 저장하는 함수.
-
-    Args:
-        db (Session): SQLAlchemy 세션 객체.
-        user_id (str): 점수를 등록한 사용자 ID.
-        score_list (List[ScoreCreateRequest]): 음식 ID 및 점수 목록.
-
-    Returns:
-        List[ScoreResponse]: 저장된 점수 정보 리스트.
-
-    Raises:
-        HTTPException: 음식 ID가 존재하지 않을 경우 400 예외 발생.
-    """
-    new_scores = []
-
-    for score in score_list:
-        food = db.query(Food).filter(Food.id == score.food_id).first()
-
-        if not food:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid food_id. Food does not exist."
-            )
-
-        new_score = Score(
-            user_id=user_id,
-            food_id=score.food_id,
-            score=score.score,
-            created_at=datetime.now()
-        )
-
-        new_scores.append(new_score)
-        db.add(new_score)
-        db.flush()
-
-    return [ScoreResponse.model_validate(new_score) for new_score in new_scores]

--- a/app/crud/scores.py
+++ b/app/crud/scores.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import HTTPException, status
+
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import and_
+
+from app.models.scores import Score
+from app.schemas.scores import ScoreCreateRequest, ScoreResponse
+from app.models.foods import Food
+from app.models.menus import Menu
+
+
+def create_food_scores(db: Session, user_id: str, score_list: List[ScoreCreateRequest]) -> List[ScoreResponse]:
+    """
+    음식에 대한 평가 점수를 저장하는 함수.
+
+    Args:
+        db (Session): SQLAlchemy 세션 객체.
+        user_id (str): 점수를 등록한 사용자 ID.
+        score_list (List[ScoreCreateRequest]): 음식 ID 및 점수 목록.
+
+    Returns:
+        List[ScoreResponse]: 저장된 점수 정보 리스트.
+
+    Raises:
+        HTTPException: 음식 ID가 존재하지 않을 경우 400 예외 발생.
+    """
+    new_scores = []
+
+    for score in score_list:
+        food = db.query(Food).filter(Food.id == score.food_id).first()
+
+        if not food:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid food_id. Food does not exist."
+            )
+
+        new_score = Score(
+            user_id=user_id,
+            food_id=score.food_id,
+            score=score.score,
+            created_at=datetime.now()
+        )
+
+        new_scores.append(new_score)
+        db.add(new_score)
+        db.flush()
+
+    return [ScoreResponse.model_validate(new_score) for new_score in new_scores]
+
+
+def get_food_scores_recent_by_menu(db: Session, user_id: str, menu_id: int) -> List[ScoreResponse]:
+    """
+    특정 메뉴에 포함된 음식들에 대해 사용자가 가장 최근에 등록한 점수를 조회합니다.
+
+    Args:
+        db (Session): SQLAlchemy 세션.
+        user_id (str): 사용자 식별자.
+        menu_id (int): 조회 대상 메뉴 ID.
+
+    Returns:
+        List[ScoreResponse]: 음식별 최근 점수 목록.
+
+    Raises:
+        HTTPException:
+            - 메뉴가 존재하지 않을 경우 400 에러.
+            - 유저가 남긴 점수가 전혀 없을 경우 400 에러.
+    """
+    menu = db.query(Menu).filter(Menu.id == menu_id).first()
+    
+    if not menu:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid menu_id. Menu does not exist."
+        )
+    
+    scores = [
+        score for food in menu.foods
+        if (score := db.query(Score)
+            .filter(and_(Score.user_id == user_id, Score.food_id == food.id))
+            .order_by(Score.id.desc())
+            .first())
+    ]
+    
+    if not scores:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No scores found for this menu."
+        )
+    
+    return [ScoreResponse.model_validate(score) for score in scores]

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routers import auth, users, menus, foods, logs, statistics, votes
+from app.routers import auth, users, menus, foods, logs, statistics, votes, scores
 from app.database import init_db
 from app.config import get_settings
 from app.middlewares.logging import LoggingMiddleware
@@ -32,6 +32,7 @@ app.include_router(foods.router, prefix="/api/v1", tags=["foods"])
 app.include_router(logs.router, prefix="/api/v1", tags=["logs"])
 app.include_router(statistics.router, prefix="/api/v1", tags=["statistics"])
 app.include_router(votes.router, prefix="/api/v1", tags=["votes"])
+app.include_router(scores.router, prefix="/api/v1", tags=["scores"])
 
 
 @app.get("/api/v1/health", tags=["system"])

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -1,15 +1,11 @@
-from typing import List
-
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies.auth import get_current_admin
-from app.dependencies.user import get_user_id
 from app.crud import foods
 from app.models.users import User
 from app.schemas.foods import FoodPatchRequest, FoodResponse
-from app.schemas.scores import ScoreCreateRequest, ScoreResponse
 
 
 router = APIRouter(
@@ -43,29 +39,3 @@ async def update_food(
     """
     updated_food = foods.update_food(db, food_id, new_food)
     return updated_food
-
-
-@router.post("/score", response_model=List[ScoreResponse], status_code=status.HTTP_201_CREATED)
-async def score_food(
-    score_list: List[ScoreCreateRequest],
-    db: Session = Depends(get_db),
-    user_id: str = Depends(get_user_id)
-):
-    """
-    음식에 대한 점수를 등록하는 API.
-
-    사용자로부터 음식 ID와 점수 리스트를 받아 각 점수를 저장합니다.
-
-    Args:
-        score_list (List[ScoreCreateRequest]): 점수 생성 요청 리스트.
-        db (Session): SQLAlchemy 데이터베이스 세션.
-        user_id (str): 요청자의 사용자 ID (헤더에서 추출).
-
-    Returns:
-        List[ScoreResponse]: 생성된 점수 정보 리스트.
-
-    Raises:
-        HTTPException: 유효하지 않은 food_id 또는 DB 오류 발생 시 예외.
-    """
-    new_score = foods.score_food(db, user_id, score_list)
-    return new_score

--- a/app/routers/scores.py
+++ b/app/routers/scores.py
@@ -1,0 +1,71 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.user import get_user_id
+from app.crud import scores
+from app.schemas.scores import ScoreCreateRequest, ScoreResponse
+
+
+router = APIRouter(
+    prefix="/scores", 
+    tags=["scores"],
+    responses={404: {"description": "Not found"}}
+)
+
+
+@router.post("/", response_model=List[ScoreResponse], status_code=status.HTTP_201_CREATED)
+async def create_food_scores(
+    score_list: List[ScoreCreateRequest],
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_user_id)
+):
+    """
+    음식에 대한 점수를 등록하는 API.
+
+    사용자로부터 음식 ID와 점수 리스트를 받아 각 점수를 저장합니다.
+
+    Args:
+        score_list (List[ScoreCreateRequest]): 점수 생성 요청 리스트.
+        db (Session): SQLAlchemy 데이터베이스 세션.
+        user_id (str): 요청자의 사용자 ID (헤더에서 추출).
+
+    Returns:
+        List[ScoreResponse]: 생성된 점수 정보 리스트.
+
+    Raises:
+        HTTPException: 유효하지 않은 food_id 또는 DB 오류 발생 시 예외.
+    """
+    new_score = scores.create_food_scores(db, user_id, score_list)
+    return new_score
+
+
+@router.get("/{menu_id}", response_model=List[ScoreResponse], status_code=status.HTTP_200_OK)
+async def get_food_scores_recent_by_menu(
+    menu_id: int,
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_user_id)
+):
+    """
+    특정 메뉴에 포함된 음식들에 대해 사용자가 가장 최근에 남긴 점수들을 조회합니다.
+
+    - 사용자는 각 음식마다 여러 개의 점수를 남길 수 있지만, 이 API는 **가장 최근 점수 1개씩만 반환**합니다.
+    - 메뉴에 포함된 음식 중, 사용자가 점수를 남기지 않은 음식은 응답에서 제외됩니다.
+
+    Args:
+        menu_id (int): 점수를 조회할 대상 메뉴 ID.
+        db (Session): SQLAlchemy 세션 객체.
+        user_id (str): 사용자 식별자 (헤더에서 추출됨).
+
+    Returns:
+        List[ScoreResponse]: 음식별 최근 점수 목록.
+
+    Raises:
+        HTTPException:
+            - 존재하지 않는 메뉴 ID일 경우 400 에러.
+            - 사용자가 해당 메뉴에 속한 음식에 대해 점수를 남기지 않았을 경우 400 에러.
+    """
+    score = scores.get_food_scores_recent_by_menu(db, user_id, menu_id)
+    return score


### PR DESCRIPTION
- 사용자가 특정 메뉴에 속한 음식들에 대해 남긴 가장 최근의 점수를 조회하는 API 구현
- 점수는 음식별로 최신 1건만 반환되며, 점수가 없는 음식은 제외됨
- 메뉴 유효성 검증 및 점수 없을 경우 예외 처리 추가
- ScoreResponse 모델 및 라우터, 서비스 함수 정의